### PR TITLE
Added golden tests using the Diff library

### DIFF
--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -37,4 +37,5 @@ library
     mtl,
     optparse-applicative,
     filepath,
-    temporary >= 1.1
+    temporary >= 1.1,
+    Diff >= 0.3 && < 1.0


### PR DESCRIPTION
This seems to work. Note that due to a restrictive type signature of `ppDiff` in `Data.Algorithm.DiffOutput` function `diffCmp` has to convert the inputs to Haskell Strings, which might hurt performance/memory usage. At this time I'm not sure how hard it would be to adapt `ppDiff` to accept `ByteString`s (or, maybe, any instance of `Show`). I might look into that at a later time. This is for issue #2 
