### PR TITLE
Bytestring >= 0.10 needed for `toStrict`

### DIFF
--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
     base ==4.*,
     tasty >= 0.8,
-    bytestring,
+    bytestring >= 0.10,
     process,
     mtl,
     optparse-applicative,


### PR DESCRIPTION
`Data.ByteString.Lazy.toStrict` is only exported from bytestring-0.10 onwards. Building on travis with GHC 7.4 fails without this constraint.