### PR TITLE
Resurrect old GHC support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.9.20200125
+# version: 0.9.20200214
 #
 version: ~> 1.0
 language: c
@@ -43,6 +43,18 @@ jobs:
       os: linux
     - compiler: ghc-8.0.2
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.0.2","cabal-install-3.0"]}}
+      os: linux
+    - compiler: ghc-7.10.3
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.10.3","cabal-install-3.0"]}}
+      os: linux
+    - compiler: ghc-7.8.4
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.8.4","cabal-install-3.0"]}}
+      os: linux
+    - compiler: ghc-7.6.3
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.6.3","cabal-install-3.0"]}}
+      os: linux
+    - compiler: ghc-7.4.2
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.4.2","cabal-install-3.0"]}}
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
@@ -137,5 +149,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
 
-# REGENDATA ("0.9.20200125",["tasty-golden.cabal"])
+# REGENDATA ("0.9.20200214",["tasty-golden.cabal"])
 # EOF

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -23,7 +23,11 @@ build-type:          Simple
 cabal-version:       >=1.14
 extra-source-files:  CHANGELOG.md
 Tested-With:
-  GHC ==8.0.2 ||
+  GHC ==7.4.2 ||
+      ==7.6.3 ||
+      ==7.8.4 ||
+      ==7.10.3 ||
+      ==8.0.2 ||
       ==8.2.2 ||
       ==8.4.4 ||
       ==8.6.5 ||


### PR DESCRIPTION
I made revision to `2.3.2.1` https://hackage.haskell.org/package/tasty-golden-2.3.2.1/revisions/

The old GHC support is import for `Cabal`, which tries to support old GHCs (for custom setups, 5 year window at least).

Thus I added CI jobs for older GHCs as well