### PR TITLE
Show default size-cutoff value in --help output

### DIFF
--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -17,7 +17,7 @@ Homepage:            https://github.com/feuerbach/tasty-golden
 Bug-reports:         https://github.com/feuerbach/tasty-golden/issues
 author:              Roman Cheplyaka
 maintainer:          Roman Cheplyaka <roma@ro-che.info>
--- copyright:           
+-- copyright:
 category:            Testing
 build-type:          Simple
 cabal-version:       >=1.14
@@ -56,7 +56,7 @@ library
     bytestring >= 0.9.2.1,
     process,
     mtl,
-    optparse-applicative,
+    optparse-applicative >= 0.3.1,
     filepath,
     temporary,
     tagged,


### PR DESCRIPTION
It wasn't clear to me from the current `--help` output that the default `--size-cutoff` value is 1000 bytes. This patch tweaks the `--help` output to make this explicit.