### PR TITLE
goldenVsFileDiff: Use getFileStatus on the golden file (#32)

### DIFF
--- a/Test/Tasty/Golden.hs
+++ b/Test/Tasty/Golden.hs
@@ -72,6 +72,7 @@ import System.Process
 import System.Exit
 import System.FilePath
 import System.Directory
+import System.PosixCompat.Files
 import Control.Exception
 import Control.Monad
 import qualified Data.Set as Set
@@ -138,7 +139,11 @@ goldenVsFileDiff name cmdf ref new act =
   askOption $ \sizeCutoff ->
   goldenTest
     name
-    (return ())
+    (getFileStatus ref >> return ())
+        -- Use getFileStatus to check if the golden file exists. If the file
+        -- doesn't exist, getFileStatus will throw an isDoesNotExistError that
+        -- runGolden will handle by creating the golden file before proceeding.
+        -- See #32.
     act
     (cmp sizeCutoff)
     upd

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -64,7 +64,8 @@ library
     containers,
     directory,
     async,
-    text
+    text,
+    unix-compat
 
 Test-suite test
   Default-language:


### PR DESCRIPTION
`goldenVsFileDiff` previously would never check if the golden file exists before running `diff`. This went against `runGolden`'s expectation that missing golden files would raise an exception, as `runGolden` would handle such exceptions by creating the golden file. To ensure that missing golden files in `goldenVsFileDiff` cause an exception to be thrown, this patch uses `getFileStatus` from the `unix-compat` library to `stat` the golden file, which will throw the appropriate exception if the golden file does not exist.

Fixes #32.