### PR TITLE
Add option to delete output files if there a duplicate golden file is available 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changes
 =======
 
+* Add an option to remove the output file after a test has run, if there is
+  a golden file, or one has been created
+
 Version 2.3.3.3
 ---------------
 

--- a/Test/Tasty/Golden.hs
+++ b/Test/Tasty/Golden.hs
@@ -86,15 +86,17 @@ goldenVsFile
   -> IO () -- ^ action that creates the output file
   -> TestTree -- ^ the test verifies that the output file contents is the same as the golden file contents
 goldenVsFile name ref new act =
-  goldenTest
+  goldenTest2
     name
     (readFileStrict ref)
     (act >> readFileStrict new)
     cmp
     upd
+    del
   where
   cmp = simpleCmp $ printf "Files '%s' and '%s' differ" ref new
   upd = createDirectoriesAndWriteFile ref
+  del = removeFile new
 
 -- | Compare a given string against the golden file's contents.
 goldenVsString
@@ -137,7 +139,7 @@ goldenVsFileDiff
   -> TestTree
 goldenVsFileDiff name cmdf ref new act =
   askOption $ \sizeCutoff ->
-  goldenTest
+  goldenTest2
     name
     (getFileStatus ref >> return ())
         -- Use getFileStatus to check if the golden file exists. If the file
@@ -147,6 +149,7 @@ goldenVsFileDiff name cmdf ref new act =
     act
     (cmp sizeCutoff)
     upd
+    del
   where
   cmd = cmdf ref new
   cmp sizeCutoff _ _
@@ -162,6 +165,7 @@ goldenVsFileDiff name cmdf ref new act =
       _ -> Just . unpackUtf8 . truncateLargeOutput sizeCutoff $ out
 
   upd _ = readFileStrict new >>= createDirectoriesAndWriteFile ref
+  del = removeFile new
 
 -- | Same as 'goldenVsString', but invokes an external diff command.
 goldenVsStringDiff

--- a/Test/Tasty/Golden/Advanced.hs
+++ b/Test/Tasty/Golden/Advanced.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 module Test.Tasty.Golden.Advanced
-  ( -- * The main function
-    goldenTest
+  ( -- * The main functions
+    goldenTest,
+    goldenTest2
   )
 where
 
@@ -32,4 +33,35 @@ goldenTest
   -> (a -> IO ())
     -- ^ update the golden file
   -> TestTree
-goldenTest t golden test cmp upd = singleTest t $ Golden golden test cmp upd
+goldenTest t golden test cmp upd = singleTest t $ Golden golden test cmp upd (return ())
+
+-- | A variant of 'goldenTest' that also provides for deleting the output
+-- file. The 'Internal.DeleteOuputFile' option controls the circumstances in which
+-- the output file is to be deleted.
+goldenTest2
+  :: TestName -- ^ Test name
+  -> IO a
+    -- ^ Get the golden correct value
+    --
+    -- Note that this action may be followed by the update function call.
+    --
+    -- Therefore, this action *should avoid* reading the file lazily;
+    -- otherwise, the file may remain half-open and the update action will
+    -- fail.
+  -> IO a
+    -- ^ Get the tested value (in this case from the output file)
+  -> (a -> a -> IO (Maybe String))
+    -- ^ Comparison function.
+    --
+    -- If two values are the same, it should return 'Nothing'. If they are
+    -- different, it should return an error that will be printed to the user.
+    -- First argument is the golden value.
+    --
+    -- The function may use 'IO', for example, to launch an external @diff@
+    -- command.
+  -> (a -> IO ())
+    -- ^ Update the golden file
+  -> IO ()
+    -- ^ Action to delete the output file
+  -> TestTree
+goldenTest2 t golden test cmp upd del = singleTest t $ Golden golden test cmp upd del

--- a/Test/Tasty/Golden/Internal.hs
+++ b/Test/Tasty/Golden/Internal.hs
@@ -70,8 +70,6 @@ instance IsOption SizeCutoff where
 data DeleteOutputFile
   = Never  -- ^ Never delete the output file (default)
   | OnPass -- ^ Delete the output file if the test passes
-  | OnFail -- ^ Ditto, if the test fails.  (Seems unlikely to be commonly 
-           --   used, but provided for completeness.)
   | Always -- ^ Always delete the output file. (May not be commonly used,
            --   but provided for completeness.)
   deriving (Eq, Ord, Typeable, Show)
@@ -89,14 +87,13 @@ instance IsOption DeleteOutputFile where
   optionName = return "delete-output"
   optionHelp = return "If there is a golden file, when to delete output files"
   showDefaultValue =  Just . displayDeleteOutputFile
-  optionCLParser = mkOptionCLParser $ metavar "never|onpass|onfail|always"
+  optionCLParser = mkOptionCLParser $ metavar "never|onpass|always"
 
 parseDeleteOutputFile :: String -> Maybe DeleteOutputFile
 parseDeleteOutputFile s =
   case map toLower s of
     "never"  -> Just Never
     "onpass" -> Just OnPass
-    "onfail" -> Just OnFail
     "always" -> Just Always
     _        -> Nothing
 
@@ -154,7 +151,6 @@ runGolden (Golden getGolden getTested cmp update delete) opts = do
                 -- Make sure that the result is fully evaluated and doesn't depend
                 -- on yet un-read lazy input
                 evaluate . rnf $ reason
-                when (delOut `elem` [Always, OnFail]) delete
                 return $ testFailed reason
 
               Nothing -> do


### PR DESCRIPTION
Thanks for your instructions.  They made it straightforward to add the option.

I've taken the liberty of adding a github workflow to illustrate that it seems to work as expected.

There are a few extra tweaks that could be done:
* the cabal version syntax
* some apparently redundant libraries and imports (eg, Data.Monoid, System.Process, mtl, async)
but they'd be for another PR.