### PR TITLE
Update for process 1.6.8, recommend -threaded and head comments

### DIFF
--- a/Test/Tasty/Golden.hs
+++ b/Test/Tasty/Golden.hs
@@ -207,17 +207,15 @@ goldenVsFileDiff name cmdf ref new act =
     | otherwise = do
     (_, Just sout, _, pid) <- createProcess
                                 (proc (head cmd) (tail cmd))
-                                {  std_out = CreatePipe
-#ifdef MIN_VERSION_process
+                                {   std_out = CreatePipe
 #if MIN_VERSION_process(1,6,8)
 -- On Windows use_process_jobs indicates that we should wait for
 -- the entire process tree to finish before unblocking.
 -- On POSIX systems the flag is ignored.
 --
--- Unfortunately the process job support is unreliable in @process@ releases
+-- Unfortunately process job support is unreliable in @process@ releases
 -- prior to 1.6.8, so we disable it in these versions.
                                   , use_process_jobs = True
-#endif
 #endif
                                 }
 
@@ -281,12 +279,10 @@ goldenVsStringDiff name cmdf ref act =
 
     (_, Just sout, _, pid) <- createProcess
                                 (proc (head cmd) (tail cmd))
-                                { std_out = CreatePipe
-#ifdef MIN_VERSION_process
+                                {   std_out = CreatePipe
 #if MIN_VERSION_process(1,6,8)
 -- See goldenVsFileDiff
                                   , use_process_jobs = True
-#endif
 #endif
                                 }
  

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -54,7 +54,7 @@ library
     base >= 4.7,
     tasty >= 1.3,
     bytestring >= 0.9.2.1,
-    process,
+    process >= 1.6.10.0,
     mtl,
     optparse-applicative >= 0.3.1,
     filepath,
@@ -87,6 +87,7 @@ Test-suite test
     , temporary
   if (flag(build-example))
     cpp-options: -DBUILD_EXAMPLE
+  Ghc-options: -threaded
 
 flag build-example
   default: False
@@ -112,3 +113,4 @@ executable example
     , bytestring
     , tasty
     , tasty-golden
+  Ghc-options: -threaded

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -54,7 +54,7 @@ library
     base >= 4.7,
     tasty >= 1.3,
     bytestring >= 0.9.2.1,
-    process >= 1.6.10.0,
+    process,
     mtl,
     optparse-applicative >= 0.3.1,
     filepath,


### PR DESCRIPTION
This addresses #42.

I have not fixed up the cabal file completely to avoid breaking Travis.  Cabal tells me that the version bounds ought to be
```
async                >= 2.2.2 && < 2.3,
base                 >= 4.14.0 && < 4.15,
bytestring           >= 0.10.10 && < 0.11,
deepseq              >= 1.4.4 && < 1.5,
text                 >= 1.2.3 && < 1.3,
containers           >= 0.6.2 && < 0.7,
directory            >= 1.3.6 && < 1.4,
filepath             >= 1.4.2 && < 1.5,
mtl                  >= 2.2.2 && < 2.3,
optparse-applicative >= 0.15.1 && < 0.16,
process              >= 1.6.8 && < 1.7,
tagged               >= 0.8.6 && < 0.9,
tasty                >= 1.3.1 && < 1.4,
temporary            >= 1.3 && < 1.4,
unix-compat          >= 0.5.2 && < 0.6,
```
which is not ideal, as some of the Windows fixes are actually in `process` 1.6.10. As it is, a couple of the older ghcs only seem to pick up 1.2.  I don't know whether that's just Travis, or whether there is an underlying limitation.

Anyway, if there is, we can just CPP the couple of lines that are needed for Windows and advise using a recent ghc, but you may be able to spot a neater approach.