### PR TITLE
Use typed-process rather than process to launch diff

### DIFF
--- a/Test/Tasty/Golden.hs
+++ b/Test/Tasty/Golden.hs
@@ -207,17 +207,15 @@ goldenVsFileDiff name cmdf ref new act =
     | otherwise = do
     (_, Just sout, _, pid) <- createProcess
                                 (proc (head cmd) (tail cmd))
-                                {  std_out = CreatePipe
-#ifdef MIN_VERSION_process
+                                {   std_out = CreatePipe
 #if MIN_VERSION_process(1,6,8)
 -- On Windows use_process_jobs indicates that we should wait for
 -- the entire process tree to finish before unblocking.
 -- On POSIX systems the flag is ignored.
 --
--- Unfortunately the process job support is unreliable in @process@ releases
+-- Unfortunately process job support is unreliable in @process@ releases
 -- prior to 1.6.8, so we disable it in these versions.
                                   , use_process_jobs = True
-#endif
 #endif
                                 }
 
@@ -281,12 +279,10 @@ goldenVsStringDiff name cmdf ref act =
 
     (_, Just sout, _, pid) <- createProcess
                                 (proc (head cmd) (tail cmd))
-                                { std_out = CreatePipe
-#ifdef MIN_VERSION_process
+                                {   std_out = CreatePipe
 #if MIN_VERSION_process(1,6,8)
 -- See goldenVsFileDiff
                                   , use_process_jobs = True
-#endif
 #endif
                                 }
  

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -54,7 +54,7 @@ library
     base >= 4.7,
     tasty >= 1.3,
     bytestring >= 0.9.2.1,
-    process,
+    typed-process,
     mtl,
     optparse-applicative >= 0.3.1,
     filepath,
@@ -83,7 +83,7 @@ Test-suite test
     , tasty-golden
     , filepath
     , directory
-    , process
+    , typed-process
     , temporary
   if (flag(build-example))
     cpp-options: -DBUILD_EXAMPLE

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -54,7 +54,7 @@ library
     base >= 4.7,
     tasty >= 1.3,
     bytestring >= 0.9.2.1,
-    process,
+    process >= 1.6.10.0,
     mtl,
     optparse-applicative >= 0.3.1,
     filepath,
@@ -87,6 +87,7 @@ Test-suite test
     , temporary
   if (flag(build-example))
     cpp-options: -DBUILD_EXAMPLE
+  Ghc-options: -threaded
 
 flag build-example
   default: False
@@ -112,3 +113,4 @@ executable example
     , bytestring
     , tasty
     , tasty-golden
+  Ghc-options: -threaded

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -54,7 +54,7 @@ library
     base >= 4.7,
     tasty >= 1.3,
     bytestring >= 0.9.2.1,
-    process >= 1.6.10.0,
+    process,
     mtl,
     optparse-applicative >= 0.3.1,
     filepath,

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -71,7 +71,7 @@ main = defaultMain $ testGroup "Tests"
     (do
       tmp0 <- getCanonicalTemporaryDirectory
       tmp <- createTempDirectory tmp0 "golden-test"
-      callProcess "cp" ["-r", "example", tmp]
+      runProcess_ $ shell $ "cp -r example " ++ tmp
       return tmp
     )
     ({-removeDirectoryRecursive-}const $ return ()) $ \tmpIO ->
@@ -89,8 +89,7 @@ main = defaultMain $ testGroup "Tests"
           -- timings.
           --
           -- NB: cannot use multiline literals because of CPP.
-          let cmd = setWorkingDir tmp
-                  $ shell "example | " ++
+          let cmd = shell ("cd " ++ tmp ++ " && example | " ++
                       "sed -Ee 's/[[:digit:]-]+\\.actual/.actual/g; s/ \\([[:digit:].]+s\\)//' > " ++
                       our</>"tests/golden/before-accept.actual || true")
           runProcess_ cmd
@@ -103,8 +102,7 @@ main = defaultMain $ testGroup "Tests"
         (do
           tmp <- tmpIO
           our <- getCurrentDirectory
-          let cmd = setWorkingDir tmp
-                  $ shell "example --accept | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
+          let cmd = shell ("cd " ++ tmp ++ " && example --accept | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
                           our </>"tests/golden/with-accept.actual")
           runProcess_ cmd
         )
@@ -116,8 +114,7 @@ main = defaultMain $ testGroup "Tests"
         (do
           tmp <- tmpIO
           our <- getCurrentDirectory
-          let cmd = setWorkingDir tmp
-                  $ shell "example | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
+          let cmd = shell ("cd " ++ tmp ++ " && example | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
                           our</>"tests/golden/after-accept.actual")
           runProcess_ cmd
         )

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -6,7 +6,7 @@ import Test.Tasty.Golden
 import System.IO.Temp
 import System.FilePath
 import System.Directory
-import System.Process
+import System.Process.Typed
 import Data.List (sort)
 
 touch f = writeFile f ""
@@ -89,9 +89,11 @@ main = defaultMain $ testGroup "Tests"
           -- timings.
           --
           -- NB: cannot use multiline literals because of CPP.
-          callCommand ("cd " ++ tmp ++ " && example | " ++
-            "sed -Ee 's/[[:digit:]-]+\\.actual/.actual/g; s/ \\([[:digit:].]+s\\)//' > " ++
-            our</>"tests/golden/before-accept.actual || true")
+          let cmd = setWorkingDir tmp
+                  $ shell "example | " ++
+                      "sed -Ee 's/[[:digit:]-]+\\.actual/.actual/g; s/ \\([[:digit:].]+s\\)//' > " ++
+                      our</>"tests/golden/before-accept.actual || true")
+          runProcess_ cmd
         )
     , after AllFinish "/before --accept/" $ goldenVsFileDiff
         "with --accept"
@@ -101,7 +103,10 @@ main = defaultMain $ testGroup "Tests"
         (do
           tmp <- tmpIO
           our <- getCurrentDirectory
-          callCommand ("cd " ++ tmp ++ " && example --accept | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++ our </>"tests/golden/with-accept.actual")
+          let cmd = setWorkingDir tmp
+                  $ shell "example --accept | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
+                          our </>"tests/golden/with-accept.actual")
+          runProcess_ cmd
         )
     , after AllFinish "/with --accept/" $ goldenVsFileDiff
         "after --accept"
@@ -111,7 +116,10 @@ main = defaultMain $ testGroup "Tests"
         (do
           tmp <- tmpIO
           our <- getCurrentDirectory
-          callCommand ("cd " ++ tmp ++ " && example | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++ our</>"tests/golden/after-accept.actual")
+          let cmd = setWorkingDir tmp
+                  $ shell "example | sed -Ee 's/ \\([[:digit:].]+s\\)//' > " ++
+                          our</>"tests/golden/after-accept.actual")
+          runProcess_ cmd
         )
     ]
 #endif


### PR DESCRIPTION
Here, as a proof-of concept, is an alternative approach to launching `diff`, using `typed-process`.

This seems to avoid the Windows limitations (although I have left the comments in for now).

Both `cabal test` and the `example` seem to produce the right results.