### PR TITLE
Add support for bazel

### DIFF
--- a/Test/Tasty/Golden.hs
+++ b/Test/Tasty/Golden.hs
@@ -327,7 +327,7 @@ readFileStrict path = do
   return s
 
 unpackUtf8 :: LBS.ByteString -> String
-unpackUtf8 = LT.unpack . LT.decodeUtf8
+unpackUtf8 = LT.unpack . LT.decodeUtf8 LT.lenientDecode
 
 runDiff
   :: [String] -- ^ the diff command


### PR DESCRIPTION
This commit is super specific to bazel environment.

In Bazel, when you run a test with `bazel test`, they are run in a
sandbox, so files written by the golden test `--accept` will only be
modified in the sandbox, but not in your original source tree.

This commit detects that you are using bazel and change the output
directory to the original directory in your source tree.

@UnkindPartition I'm opening the MR for the record, feel free to ignore it