### PR TITLE
Release 2.3.6

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20251211
+# version: 0.19.20260128
 #
-# REGENDATA ("0.19.20251211",["github","tasty-golden.cabal"])
+# REGENDATA ("0.19.20260128",["github","tasty-golden.cabal"])
 #
 name: Haskell-CI
 on:
@@ -35,10 +35,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.14.0.20251128
+          - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.14.0.20251128
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.14.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
@@ -134,21 +134,6 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -159,7 +144,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -187,18 +172,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -222,7 +195,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -254,9 +227,6 @@ jobs:
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(tasty-golden)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -265,7 +235,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -296,7 +266,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -78,6 +78,10 @@ jobs:
     - name: Create stack.yaml
       run:  |
         echo "resolver: ${{ matrix.plan.resolver }}" > stack.yaml
+      # echo "flags: { tasty-golden: { build-example: true }}" >> stack.yaml
+      # Andreas Abel, 2025-12-15
+      # The golden values created by the example are not portable,
+      # so running the example test on CI fails.
 
     - name: Build dependencies
       run:  stack test --system-ghc --only-dependencies

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -21,9 +21,9 @@ jobs:
         os: [ubuntu-latest]
         plan:
           - ghc: '9.12.2'
-            resolver: 'nightly-2025-12-10'
+            resolver: 'nightly-2025-12-30'
           - ghc: '9.10.3'
-            resolver: 'lts-24.23'
+            resolver: 'lts-24.28'
           - ghc: '9.8.4'
             resolver: 'lts-23.28'
           - ghc: '9.6.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Version 2.3.6
 * Option `--no-create-file` now available internally as `NoCreateFile`
   ([Issue #50](https://github.com/UnkindPartition/tasty-golden/issues/50))
 * Drop support for GHC 7, remove obsolete `deriving Typeable`
-* Tested with GHC 8.0 - 9.14.0
+* Tested with GHC 8.0 - 9.14.1
 
-_Andreas Abel, 2025-12-15_
+_Andreas Abel, 2026-02-01_
 
 Version 2.3.5
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 Changes
 =======
 
-Unreleased
-----------
+Version 2.3.6
+-------------
 
-* Drop support for GHC 7, remove obsoleted `deriving Typeable`
+* Option `--no-create-file` now available internally as `NoCreateFile`
+  ([Issue #50](https://github.com/UnkindPartition/tasty-golden/issues/50))
+* Drop support for GHC 7, remove obsolete `deriving Typeable`
+* Tested with GHC 8.0 - 9.14.0
+
+_Andreas Abel, 2025-12-15_
 
 Version 2.3.5
 -------------
 
-* Fixes for launching external processes (like diff) on Windows
-* Update the golden file on --accept if decoding the golden file failed with an exception
-* Do not depend on unix-compat
+* Fixes for launching external processes (like `diff`) on Windows
+* Update the golden file on `--accept` if decoding the golden file failed with an exception
+* Do not depend on `unix-compat`
 
 Version 2.3.4
 -------------
@@ -76,12 +81,12 @@ contract.
 Version 2.3.0.2
 ---------------
 
-Switch from temporary-rc to temporary
+Switch from `temporary-rc` to `temporary`
 
 Version 2.3.0.1
 ---------------
 
-Impose a lower bound version constraint on bytestring.
+Impose a lower bound version constraint on `bytestring`.
 
 Version 2.3
 -----------

--- a/Test/Tasty/Golden/Internal.hs
+++ b/Test/Tasty/Golden/Internal.hs
@@ -39,6 +39,8 @@ instance IsOption AcceptTests where
 
 -- | This option, when set to 'True', specifies to error when a file does
 -- not exist, instead of creating a new file.
+--
+-- @since 2.3.6
 newtype NoCreateFile = NoCreateFile Bool
   deriving (Eq, Ord)
 instance IsOption NoCreateFile where

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -1,4 +1,4 @@
-cabal-version:       1.14
+cabal-version:       2.0
 name:                tasty-golden
 version:             2.3.6
 synopsis:            Golden tests support for tasty
@@ -93,6 +93,7 @@ Test-suite test
     , temporary
   if (flag(build-example))
     cpp-options: -DBUILD_EXAMPLE
+    build-tool-depends: tasty-golden:example
   Ghc-options: -threaded
 
 flag build-example

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.14
 name:                tasty-golden
-version:             2.3.5
+version:             2.3.6
 synopsis:            Golden tests support for tasty
 description:
   This package provides support for «golden testing».

--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -21,8 +21,12 @@ maintainer:          Roman Cheplyaka <roma@ro-che.info>
 -- copyright:
 category:            Testing
 build-type:          Simple
-extra-source-files:
+
+extra-doc-files:
   CHANGELOG.md
+  README.md
+
+extra-source-files:
   example/golden/fail/*.golden
   example/golden/success/*.golden
   tests/golden/*.golden

--- a/tests/golden/before-accept.golden
+++ b/tests/golden/before-accept.golden
@@ -7,6 +7,7 @@ Tests
   Failing tests
     goldenVsFile:       FAIL
       Files 'example/golden/fail/goldenVsFile.golden' and 'example/golden/fail/goldenVsFile.actual' differ
+      Use -p '$0=="Tests.Failing tests.goldenVsFile"' to rerun this test only.
     goldenVsFileDiff:   FAIL
       1d0
       < 1
@@ -35,6 +36,7 @@ Tests
       169d156
       <<truncated>
       Use --accept or increase --size-cutoff to see full output.
+      Use -p '/Failing tests.goldenVsFileDiff/' to rerun this test only.
     goldenVsString:     FAIL
       Test output was different from 'example/golden/fail/goldenVsString.golden'. It was:
       2
@@ -87,8 +89,9 @@ Tests
       55
       56<truncated>
       Use --accept or increase --size-cutoff to see full output.
+      Use -p '$0=="Tests.Failing tests.goldenVsString"' to rerun this test only.
     goldenVsStringDiff: FAIL
-      Test output was different from 'example/golden/fail/goldenVsStringDiff.golden'. Output of ["diff","example/golden/fail/goldenVsStringDiff.golden","/tmp/goldenVsStringDiff.actual"]:
+      Test output was different from 'example/golden/fail/goldenVsStringDiff.golden'. Output of ["diff","example/golden/fail/goldenVsStringDiff.golden","/private/var/folders/19/d9jtc4c5365g3c_5jjk7m_980000gn/T/goldenVsStringDiff.actual"]:
       1d0
       < 1
       4d2
@@ -116,5 +119,6 @@ Tests
       169d156
       <<truncated>
       Use --accept or increase --size-cutoff to see full output.
+      Use -p '/Failing tests.goldenVsStringDiff/' to rerun this test only.
 
 4 out of 8 tests failed


### PR DESCRIPTION
- **Bump to 2.3.6 and CHANGELOG**
  

- **Make `cabal test -f build-example` work**
  Fixed by adding the example executable as dependency to the testsuite.
  This needs `build-tool-depends` only available from `cabal-version: 2.0`.
  

- **Add README to package**

Candidate: https://hackage.haskell.org/package/tasty-golden-2.3.6/candidate
  